### PR TITLE
ci: beta channel

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,100 @@
+name: Beta Build
+
+# Opt-in beta builds. Two ways to trigger:
+#  - Merge a PR into main that carries the "beta" label.
+#  - Run this workflow manually (Actions → Beta Build → Run workflow) to queue
+#    the current state of main as a beta.
+# Each run builds a signed, beta-versioned AAB and uploads it to the Play
+# internal track as a DRAFT (nothing goes live until you publish/promote it in
+# the console), plus a sideloadable APK as a run artifact.
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Serialize so two beta builds never race on the same versionCode / track.
+concurrency:
+  group: beta-build
+  cancel-in-progress: false
+
+jobs:
+  beta:
+    name: Beta Build
+    # Manual dispatch, OR a merged PR that carried the "beta" label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'beta'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Full history so `git rev-list --count` yields the true commit count.
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Compute beta version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Beta = a build of the UPCOMING release. Read that version from
+          # release-please's open release PR; fall back to the manifest (the
+          # last released version) when no release is pending.
+          NEXT=$(gh pr list --state open --json title,headRefName \
+            --jq '.[] | select(.headRefName | startswith("release-please")) | .title' 2>/dev/null \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+          if [ -z "$NEXT" ]; then
+            NEXT=$(python3 -c "import json; print(json.load(open('.release-please-manifest.json'))['.'])")
+          fi
+          COMMITS=$(git rev-list --count HEAD)
+          echo "version_name=${NEXT}-beta.${COMMITS}" >> "$GITHUB_OUTPUT"
+          echo "version_code=$((COMMITS + 75))" >> "$GITHUB_OUTPUT"
+          echo "Beta ${NEXT}-beta.${COMMITS} (versionCode $((COMMITS + 75)))"
+
+      - name: Decode signing keystore
+        env:
+          SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE }}
+        run: echo "$SIGNING_KEYSTORE" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+
+      - name: Build signed beta APK + AAB
+        env:
+          VERSION_NAME_OVERRIDE: ${{ steps.ver.outputs.version_name }}
+          VERSION_CODE: ${{ steps.ver.outputs.version_code }}
+          SIGNING_KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
+          SIGNING_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease bundleRelease --no-daemon
+
+      - name: Upload beta APK artifact (sideload copy)
+        uses: actions/upload-artifact@v4
+        with:
+          name: azuracast-beta-${{ steps.ver.outputs.version_name }}
+          path: app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
+
+      - name: Upload beta AAB to Play internal (draft)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.larvey.azuracastplayer
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: draft
+          releaseName: ${{ steps.ver.outputs.version_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the commit-count versionCode is correct.
+          fetch-depth: 0
+
+      - name: Compute versionCode from commit count
+        id: vc
+        run: echo "version_code=$(( $(git rev-list --count HEAD) + 75 ))" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -59,6 +66,7 @@ jobs:
 
       - name: Build signed release APK + AAB
         env:
+          VERSION_CODE: ${{ steps.vc.outputs.version_code }}
           SIGNING_KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
           SIGNING_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
@@ -102,6 +110,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the commit-count versionCode is correct.
+          fetch-depth: 0
+
+      - name: Compute versionCode from commit count
+        id: vc
+        run: echo "version_code=$(( $(git rev-list --count HEAD) + 75 ))" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -119,6 +134,7 @@ jobs:
 
       - name: Build signed release APK
         env:
+          VERSION_CODE: ${{ steps.vc.outputs.version_code }}
           SIGNING_KEYSTORE_PATH: ${{ runner.temp }}/release.keystore
           SIGNING_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,10 +308,17 @@ Non-`main` branches are protected by a **ruleset** (require PR, signed commits, 
    - attaches the **APK** to the public GitHub Release, and
    - uploads the **AAB** privately to the **Play Console internal testing track** (via `r0adkll/upload-google-play`). The AAB is never attached to the public Release. The `nightly` pre-release gets an APK only (no Play upload).
 
+### Beta channel — [.github/workflows/beta.yml](.github/workflows/beta.yml)
+Beta is a **distribution channel, not a separate version lineage** — release-please still owns the single stable SemVer line; betas are just builds of the *upcoming* version delivered to a testing track. Deliberately **not** using release-please's prerelease mode (it wants a separate branch/component and fights a single-`main` flow).
+- **Triggers (opt-in):** merging a PR into `main` that carries the **`beta`** label, or a manual **workflow_dispatch** ("Run workflow") to queue the current state of `main`.
+- **Version:** `versionName` = `<next>-beta.<commitCount>` where `<next>` is read from release-please's open release PR title (falls back to the manifest). Passed to Gradle via `VERSION_NAME_OVERRIDE`.
+- **Delivery:** signed **AAB → Play internal track as a `draft`** (nothing goes live until you publish/promote it), plus a sideloadable **APK as a run artifact**. You promote internal → your beta track manually in the console.
+- Betas do **not** touch the stable production line, the GitHub Releases, or the `nightly` pre-release.
+
 ### Where the version lives
-- **`versionName`** in [app/build.gradle.kts](app/build.gradle.kts) is owned by release-please — it's the line tagged `// x-release-please-version`. **Never edit the version string by hand** and keep that trailing comment or the updater won't find it.
+- **`versionName`** in [app/build.gradle.kts](app/build.gradle.kts) is owned by release-please — it's the line tagged `// x-release-please-version`. **Never edit the version string by hand** and keep that trailing comment or the updater won't find it. Beta CI builds relabel it via the `VERSION_NAME_OVERRIDE` env override (the annotated line is untouched).
 - Source of truth is [.release-please-manifest.json](.release-please-manifest.json) (mirrored in [version.txt](version.txt)). Config is [release-please-config.json](release-please-config.json). `bootstrap-sha` there pins the history start (commit `fce73a6`) so the first changelog doesn't ingest the old non-conventional history — **remove `bootstrap-sha` after the first release cuts.**
-- **`versionCode`** is NOT managed by release-please (it only does SemVer strings). It's computed in `build.gradle.kts` as `GITHUB_RUN_NUMBER + 75` so it always increases and never drops below the last published `75`; local builds fall back to `75`.
+- **`versionCode`** is NOT managed by release-please. Every CI build that can be uploaded to Play passes `VERSION_CODE = (git rev-list --count HEAD) + 75` — the **main commit count**, which is workflow-independent and strictly monotonic across the release *and* beta pipelines (unlike `GITHUB_RUN_NUMBER`, which is per-workflow and resets on a workflow rename). `build.gradle.kts` reads `VERSION_CODE`; local/PR builds fall back to `75`. (Re-dispatching a beta on an *unchanged* `main` reuses the same commit count → same code → Play rejects it as a duplicate; that's expected — merge a commit first.)
 - The current line before release-please's first bump is `1.1.0`. The first release-please Release will be the next bump from there (e.g. `1.1.1` for a `fix`, `1.2.0` for a `feat`). If you want `1.1.0` itself cut as a Release, add `Release-As: 1.1.0` to a commit footer once.
 
 ### One-time setup the maintainer must do (outside code)
@@ -322,4 +329,5 @@ Non-`main` branches are protected by a **ruleset** (require PR, signed commits, 
   Without these the build job fails (the app-level signing config no-ops locally, leaving unsigned release builds — that's expected off-CI).
 - **Play upload secret**: `PLAY_SERVICE_ACCOUNT_JSON` — full JSON of a Google Play Developer API service account with "Release to testing tracks" permission, used to push the AAB to the internal track. (Google may require the app's very first release be made manually in the console before API uploads are accepted.)
 - **Note on required checks**: PRs opened by the default `GITHUB_TOKEN` don't trigger *other* workflows. If you later add required status checks that must run on the release PR, switch the action's `token:` to a PAT/App token.
+- **Beta channel** reuses the same signing + `PLAY_SERVICE_ACCOUNT_JSON` secrets (the service account's "Release to testing tracks" permission covers the internal track) — no new secrets. A repo label named **`beta`** must exist (already created) for the label trigger.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,13 +14,18 @@ android {
     applicationId = "com.larvey.azuracastplayer"
     minSdk = 26
     targetSdk = 36
-    // versionCode must strictly increase for the Play Store. In CI it is derived
-    // from the workflow run number (+ a base so it never drops below the last
-    // published 75); local builds fall back to the base.
-    versionCode = (System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull() ?: 0) + 75
+    // versionCode must strictly increase for the Play Store. CI passes VERSION_CODE
+    // computed from the main commit count (+ 75), which is workflow-independent and
+    // strictly monotonic across the release AND beta pipelines — unlike
+    // GITHUB_RUN_NUMBER, which is per-workflow and resets if a workflow is renamed.
+    // Local and PR builds fall back to 75.
+    versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 75
     // versionName is managed by release-please — it is bumped in the release PR.
     // Do not edit the version string by hand, and keep the trailing comment.
     versionName = "1.2.0" // x-release-please-version
+    // Beta CI builds relabel the version (e.g. 1.3.0-beta.245) via this env
+    // override; stable and local builds keep the release-please-managed value above.
+    System.getenv("VERSION_NAME_OVERRIDE")?.takeIf { it.isNotBlank() }?.let { versionName = it }
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }


### PR DESCRIPTION
## Summary

Adds an **opt-in beta channel** for the Android app. Beta is treated as a **distribution channel, not a separate version lineage** — release-please keeps owning the single stable SemVer line; betas are just builds of the *upcoming* version delivered to a Play testing track. (Deliberately **not** using release-please's prerelease mode, which wants a separate branch/component and fights the single-`main` flow.)

### How a beta happens (opt-in, two triggers)
[.github/workflows/beta.yml](.github/workflows/beta.yml) runs when **either**:
- a PR merged into `main` carried the **`beta`** label, **or**
- you manually run it (**Actions → Beta Build → Run workflow**) to queue the current state of `main`.

Each run:
1. Computes `versionName = <next>-beta.<commitCount>` — `<next>` read from release-please's open release PR title, falling back to the manifest (last released) when no release is pending.
2. Builds a **signed** APK + AAB with that version.
3. Uploads the **AAB to the Play internal track as a `draft`** — nothing goes live until you publish/promote it. You then promote internal → your beta track in the console when ready.
4. Uploads the **APK as a run artifact** for sideloading.

### versionCode: unified across all pipelines
A separate beta workflow has its own `GITHUB_RUN_NUMBER`, so the old `run_number + 75` scheme would collide with the release pipeline's codes and Play would reject uploads. Both pipelines now derive `versionCode` from **`git rev-list --count HEAD + 75`** (the main commit count) — workflow-independent and strictly monotonic across release *and* beta. `build.gradle.kts` reads a `VERSION_CODE` env (falls back to 75 locally). Current value: **321**, safely above the last uploaded code (~78).

### Files
- `.github/workflows/beta.yml` — new opt-in beta workflow
- `.github/workflows/release-please.yml` — release + nightly jobs now compute `VERSION_CODE` from commit count (full-history checkout)
- `app/build.gradle.kts` — `versionCode` reads `VERSION_CODE`; `versionName` accepts a `VERSION_NAME_OVERRIDE` (the release-please-annotated line is untouched)
- `CLAUDE.md` §12 — documents the beta channel

## Verification
- Env overrides proven via `aapt2`: `VERSION_CODE=320 VERSION_NAME_OVERRIDE=1.3.0-beta.245` → APK reports exactly that; no env → `75` / `1.2.0` (release-please literal).
- versionCode monotonic and above the old max; version-compute + manifest fallback validated locally.
- Full local gate green (`testDebugUnitTest` + `assembleDebug` + `assembleRelease`/R8 + `lintDebug`).
- The beta workflow's *first real run* can only happen once it's on `main` (workflow_dispatch button + label trigger require it on the default branch), so it's validated by logic/local runs, not CI on this PR.

## One-time / notes for you
- The **`beta` repo label** is already created.
- No new secrets — reuses the existing signing + `PLAY_SERVICE_ACCOUNT_JSON`.
- This PR is a **draft**, and the four PR checks skip drafts — **mark it ready for review** to run them and merge.
- Don't add the `beta` label to *this* PR unless you want a beta build to fire on its own merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
