### PR TITLE
fix #30: reset live progress bar on song change (HLS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Note the metadata quirks in `NowPlayingData.applyNowPlayingMetadata` ([classes/m
 ### Metadata polling
 Two independent pollers keep metadata fresh (radio has no client-side "track changed" signal):
 - `MainActivityViewModel.init` loops every **30 s** refreshing every saved station's metadata (while the app is foregrounded — gated by `fetchData`, toggled in `onPause`/`onResume`).
-- The Now Playing UI runs a **1 s** `updateTime` loop ([utils/UpdatePlayerTime.kt](app/src/main/java/com/larvey/azuracastplayer/utils/UpdatePlayerTime.kt)) to advance the progress bar, computing live-stream elapsed from `played_at`.
+- The Now Playing UI runs a **1 s** `updateTime` loop ([utils/UpdatePlayerTime.kt](app/src/main/java/com/larvey/azuracastplayer/utils/UpdatePlayerTime.kt)) to advance the progress bar, computing live-stream elapsed from `played_at`. Its `nowPlaying` argument is a **provider** (`() -> NowPlaying?`) read fresh each tick — the loop lives in a `LaunchedEffect(lifecycleOwner, …)` that does **not** restart on song change, so capturing the snapshot by value froze `played_at` at the first song and pegged HLS at 100% (fixed in `fix/hls-progress-reset`). Keep it a provider; don't pass `staticData.value?.nowPlaying` directly.
 
 ### Sleep timer — [session/sleepTimer/](app/src/main/java/com/larvey/azuracastplayer/session/sleepTimer/)
 `AndroidAlarmScheduler` uses `AlarmManager.setAndAllowWhileIdle(RTC_WAKEUP, ...)` to broadcast the SLEEP action at the chosen time; the service receiver stops playback. UI lives in `MediaControls` (§7). Requires exact-alarm capability. Cancel uses `cancelAll()` on API ≥ 34.

--- a/app/src/main/java/com/larvey/azuracastplayer/ui/mainActivity/MainActivity.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/ui/mainActivity/MainActivity.kt
@@ -528,7 +528,7 @@ class MainActivity : ComponentActivity() {
                                 showNowPlaying = {
                                   showNowPlayingSheet.value = true
                                 },
-                                nowPlaying = mainActivityViewModel?.nowPlayingData?.staticData?.value?.nowPlaying,
+                                nowPlaying = { mainActivityViewModel?.nowPlayingData?.staticData?.value?.nowPlaying },
                                 pause = {
                                   mediaController?.pause()
                                 },

--- a/app/src/main/java/com/larvey/azuracastplayer/ui/mainActivity/components/BottomMiniPlayer.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/ui/mainActivity/components/BottomMiniPlayer.kt
@@ -63,7 +63,7 @@ import com.larvey.azuracastplayer.utils.updateTime
 fun MiniPlayer(
   playerState: PlayerState?,
   showNowPlaying: () -> Unit,
-  nowPlaying: NowPlaying?,
+  nowPlaying: () -> NowPlaying?,
   pause: () -> Unit,
   play: () -> Unit,
   palette: MutableState<Palette?>?,
@@ -81,9 +81,10 @@ fun MiniPlayer(
     )
   )
 
-  LaunchedEffect(lifecycleOwner) {
+  val hasMedia = playerState?.currentMediaItem != null
+  LaunchedEffect(lifecycleOwner, hasMedia) {
     updateTime(
-      isVisible = playerState?.currentMediaItem != null,
+      isVisible = hasMedia,
       updateProgress = { progress, position ->
         currentProgress = progress
         currentPosition = position

--- a/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/NowPlayingPane.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/NowPlayingPane.kt
@@ -120,7 +120,7 @@ fun NowPlayingPane(
             playerState = nowPlayingViewModel.sharedMediaController.playerState.value!!,
             currentMount = nowPlayingViewModel.nowPlayingData.staticData.value?.station?.mounts?.find { it.url == nowPlayingViewModel.sharedMediaController.playerState.value?.currentMediaItem?.mediaId },
             palette = palette?.value,
-            nowPlaying = nowPlayingViewModel.nowPlayingData.staticData.value?.nowPlaying,
+            nowPlaying = { nowPlayingViewModel.nowPlayingData.staticData.value?.nowPlaying },
             isSleeping = nowPlayingViewModel.sharedMediaController.isSleeping
           )
         }

--- a/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/NowPlayingSheet.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/NowPlayingSheet.kt
@@ -197,7 +197,7 @@ fun NowPlayingSheet(
               playerState = nowPlayingViewModel.sharedMediaController.playerState.value!!,
               currentMount = nowPlayingViewModel.nowPlayingData.staticData.value?.station?.mounts?.find { it.url == nowPlayingViewModel.sharedMediaController.playerState.value?.currentMediaItem?.mediaId },
               palette = palette?.value,
-              nowPlaying = nowPlayingViewModel.nowPlayingData.staticData.value?.nowPlaying,
+              nowPlaying = { nowPlayingViewModel.nowPlayingData.staticData.value?.nowPlaying },
               isSleeping = nowPlayingViewModel.sharedMediaController.isSleeping
             )
           }

--- a/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/components/NowPlayingBottomBar.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/ui/nowplaying/components/NowPlayingBottomBar.kt
@@ -53,7 +53,7 @@ fun NowPlayingBottomBar(
   isSleeping: MutableState<Boolean>?,
   currentMount: Mount?,
   palette: Palette?,
-  nowPlaying: NowPlaying?,
+  nowPlaying: () -> NowPlaying?,
   lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 ) {
 
@@ -68,9 +68,10 @@ fun NowPlayingBottomBar(
     )
   )
 
-  LaunchedEffect(lifecycleOwner) {
+  val hasMedia = playerState.currentMediaItem != null
+  LaunchedEffect(lifecycleOwner, hasMedia) {
     updateTime(
-      isVisible = playerState.currentMediaItem != null,
+      isVisible = hasMedia,
       updateProgress = { progress, position ->
         currentProgress = progress
         currentPosition = position

--- a/app/src/main/java/com/larvey/azuracastplayer/utils/UpdatePlayerTime.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/utils/UpdatePlayerTime.kt
@@ -6,27 +6,31 @@ import com.larvey.azuracastplayer.state.PlayerState
 import kotlinx.coroutines.delay
 
 /**
- * 1-second polling loop advancing the Now Playing progress UI.
+ * 1-second polling loop advancing the Now Playing progress UI (the mini-player
+ * and the Now Playing bar both drive their progress from this).
  *
- * NOTE: for live (dynamic) streams this recomputes elapsed time from
- * `played_at`, and `playerState.player.currentPosition` here goes through the
- * client-side MediaController to the service's ForwardingPlayer override —
- * which performs the same wall-clock derivation (see LivePositionMath). The
- * two computations deliberately compose (the override's result is subtracted
- * back out); do not "simplify" one side without re-deriving the other.
+ * [nowPlaying] is a **provider**, read fresh on every tick — this is load
+ * bearing. The loop lives in a `LaunchedEffect` keyed on the lifecycle owner, so
+ * it is NOT restarted when the station advances to a new song. Capturing the
+ * `NowPlaying` snapshot by value froze `played_at` at the first song, so live
+ * (dynamic/HLS) streams never reset and the bar pegged at 100% forever; reading
+ * it live lets the derived elapsed time roll over each song. See the
+ * `ForwardingPlayer.getCurrentPosition` override in MusicPlayerService for the
+ * matching wall-clock derivation.
  */
 @androidx.annotation.OptIn(UnstableApi::class)
 suspend fun updateTime(
   isVisible: Boolean,
   updateProgress: (Float, Long) -> Unit,
   playerState: PlayerState?,
-  nowPlaying: NowPlaying?
+  nowPlaying: () -> NowPlaying?
 ) {
   while (isVisible) {
     if (playerState?.isPlaying == true) {
+      val nowPlayingSnapshot = nowPlaying()
       var currentPosition: Number = 0f
       currentPosition = if (playerState.player.isCurrentMediaItemDynamic) {
-        ((System.currentTimeMillis() / 1000).minus(nowPlaying?.playedAt!!) * 1000) - playerState.player.currentPosition
+        ((System.currentTimeMillis() / 1000).minus(nowPlayingSnapshot?.playedAt!!) * 1000) - playerState.player.currentPosition
       } else {
         playerState.player.currentPosition
       }


### PR DESCRIPTION
## The bug
When streaming **HLS**, the Now Playing progress bar does not reset when the song changes — it stays pegged at ~100%. The system media notification (lock-screen tile) resets fine, and reopening the Now Playing screen fixes it temporarily, but the **mini-player** (which can't be reopened) stays stuck at 100% forever. Progressive/ICY streams are unaffected.

## Root cause
`updateTime` ([utils/UpdatePlayerTime.kt](app/src/main/java/com/larvey/azuracastplayer/utils/UpdatePlayerTime.kt)) is a 1 s polling loop that runs inside a `LaunchedEffect` keyed **only** on the lifecycle owner, so it never restarts when the station advances to a new song. Its `nowPlaying` argument was passed **by value**, freezing `played_at` at the first song. Elapsed time `(now − frozen_played_at)` then grows without bound → 100%, forever.

- **HLS** takes the live-window branch that derives elapsed from `played_at`, so the frozen timestamp breaks it.
- **Progressive/ICY** takes the branch that reads the live `player.currentPosition` each tick, so it resets fine — which is why only HLS was affected.
- The **system tile** reads the service's `getCurrentPosition` (which reads `staticData.value` live every call), so it always reset — matching the report.

## Fix
Make `nowPlaying` a **provider** (`() -> NowPlaying?`) read fresh on every tick, in `updateTime`, `MiniPlayer`, and `NowPlayingBottomBar`; the three call sites wrap the argument in a lambda. The elapsed-time math is **unchanged** — only the staleness is fixed. Also re-key the `LaunchedEffect` on media presence so the loop starts reliably.

## Testing
- ✅ Verified on-device: HLS progress bar now resets each song in both the Now Playing screen and the mini-player; progressive streams unchanged.
- ✅ `./gradlew testDebugUnitTest` and `assembleDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)