### PR TITLE
fix: pause playback on Bluetooth/headphone disconnect (potential fix for #27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Keys: `is_grid_view` (My Radios grid vs list, default grid), `theme_type` (`Them
 [session/MusicPlayerService.kt](app/src/main/java/com/larvey/azuracastplayer/session/MusicPlayerService.kt) is a `MediaLibraryService` (`@AndroidEntryPoint`, `foregroundServiceType=mediaPlayback`). It is the single source of playback truth.
 
 ### Player setup (`onCreate`)
+- The ExoPlayer is built with `setAudioAttributes(DEFAULT, /*handleAudioFocus=*/true)` **and** `setHandleAudioBecomingNoisy(true)` — the latter is what pauses playback on headphone unplug / Bluetooth disconnect (audio-focus handling alone is unreliable for BT disconnects across devices). Keep it enabled.
 - ExoPlayer wrapped in a custom `ForwardingPlayer` that overrides:
   - `play()` → also `seekToDefaultPosition()` (jump to live edge on resume).
   - `stop()` → clears the now-playing tuple, cancels any sleep alarm, `isSleeping=false`, `clearMediaItems()`.

--- a/app/src/main/java/com/larvey/azuracastplayer/session/MusicPlayerService.kt
+++ b/app/src/main/java/com/larvey/azuracastplayer/session/MusicPlayerService.kt
@@ -154,7 +154,13 @@ class MusicPlayerService : MediaLibraryService() {
       ExoPlayer.Builder(this).setAudioAttributes(
         AudioAttributes.DEFAULT,
         true
-      ).build()
+      )
+        // Pause when audio would otherwise blast from the phone speaker after a
+        // headphone unplug or Bluetooth disconnect. Audio-focus handling alone
+        // (the `true` above) is unreliable across devices for BT disconnects;
+        // ACTION_AUDIO_BECOMING_NOISY is the signal that reliably fires.
+        .setHandleAudioBecomingNoisy(true)
+        .build()
     ) {
       override fun play() {
         super.play()


### PR DESCRIPTION
Potential fix for #27 — "Player doesn't stop on Bluetooth disconnect".

## The bug
Playback does not reliably stop when a Bluetooth device disconnects (or headphones are unplugged); audio just keeps going, often out of the phone speaker. Reporters note it doesn't *always* happen, which points at device/ROM-dependent behavior.

## Root cause
The ExoPlayer is built with audio-focus handling (`setAudioAttributes(DEFAULT, /*handleAudioFocus=*/true)`) but **without** becoming-noisy handling. Audio-focus loss on A2DP teardown is broadcast inconsistently across devices, so relying on it alone is why some users see a pause and others don't.

## Fix
Enable `setHandleAudioBecomingNoisy(true)` on the builder. ExoPlayer then listens for `ACTION_AUDIO_BECOMING_NOISY` — the signal Android fires whenever audio output is about to route to the built-in speaker — and pauses. This is the standard, reliable mechanism and also covers wired-headphone unplug.

```kotlin
ExoPlayer.Builder(this)
  .setAudioAttributes(AudioAttributes.DEFAULT, true)
  .setHandleAudioBecomingNoisy(true)   // ← added
  .build()
```

## Scope / caveats
- **Marked "potential"** because the maintainer could not reproduce the original intermittent bug on hand, so this hasn't been confirmed against a live repro. It is the well-established fix for this class of symptom.
- Addresses **pause on disconnect** only. #27 also mentions resuming on reconnect; auto-resume is intentionally **not** implemented here — it's non-standard, disabled by default in ExoPlayer, and can cause surprise playback (especially for live radio).
- One line of behavior change; no API/model changes, no ProGuard impact.
- Left as `Potential fix for #27` (no auto-close keyword) so merging won't silently close the issue.

## Testing
- ✅ `./gradlew assembleDebug` passes.
- ⚠️ Not verified against a live BT-disconnect repro (couldn't reproduce). Worth a real-device check on a device that previously exhibited the bug before closing #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)